### PR TITLE
add cache-dit to inference optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,10 @@ python test.py --prompt "A dog in red hat" --magcache
 
 See the instruction [here](comfyui)
 
+### CacheDiT
+
+cache-dit offers Fully Cache Acceleration support for Kandinsky-5 with DBCache, TaylorSeer and Cache CFG. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_kandinsky5_t2v.py) for more details.
+
 ### Beta testing
 You can apply to participate in the beta testing of the Kandinsky Video Lite via the [telegram bot](https://t.me/kandinsky_access_bot).
 


### PR DESCRIPTION
## CacheDiT

cache-dit offers Fully Cache Acceleration support for Kandinsky-5 with DBCache, TaylorSeer and Cache CFG. Visit their [example](https://github.com/vipshop/cache-dit/blob/main/examples/pipeline/run_kandinsky5_t2v.py) for more details.

- Baseline  

![](https://github.com/vipshop/cache-dit/raw/main/assets/gifs/kandinsky5.C0_L0_Q0_NONE.gif)

- w/ cache-dit: DBCache_F1B0_W8I1M0MC0_R0.05_T0O0, ~1.7x speedup  

![](https://github.com/vipshop/cache-dit/raw/main/assets/gifs/kandinsky5.C0_L0_Q0_DBCache_F1B0_W8I1M0MC0_R0.05_T0O0_S21.gif)  

```bash
python3 python3 run_kandinsky5_t2v.py --cache --Fn 1 --rdt 0.05
```
