### PR TITLE
fix: replace 9 bare excepts with specific exception types

### DIFF
--- a/kandinsky/i2i_pipeline.py
+++ b/kandinsky/i2i_pipeline.py
@@ -243,7 +243,7 @@ Rewrite Prompt: "{prompt}". Answer only with expanded prompt.""",
                 with open(adapter_config, "r") as f:
                     adapter_config = json.load(f)
                 adapter_config = LoraConfig(**adapter_config)
-            except:
+            except (FileNotFoundError, json.JSONDecodeError, TypeError):
                 raise TypeError(f"adapter_config should be an instance of PeftConfig or a path to a json file.")
         self.peft_config[adapter_name] = adapter_config
 

--- a/kandinsky/i2v_pipeline.py
+++ b/kandinsky/i2v_pipeline.py
@@ -238,7 +238,7 @@ class Kandinsky5I2VPipeline:
                 with open(adapter_config, "r") as f:
                     adapter_config = json.load(f)
                 adapter_config = LoraConfig(**adapter_config)
-            except:
+            except (FileNotFoundError, json.JSONDecodeError, TypeError):
                 raise TypeError(f"adapter_config should be an instance of PeftConfig or a path to a json file.")
         self.peft_config[adapter_name] = adapter_config
 

--- a/kandinsky/models/attention.py
+++ b/kandinsky/models/attention.py
@@ -5,19 +5,19 @@ from torch.nn.attention.flex_attention import flex_attention
 try:
     from flash_attn import flash_attn_func as flash_attention_2
     print("FlashAttention 2 is found")
-except:
+except ImportError:
     flash_attention_2 = None
 
 try:
     from flash_attn_interface import flash_attn_func as flash_attention_3
     print("FlashAttention 3 is found")
-except:
+except ImportError:
     flash_attention_3 = None
 
 try:
     import sageattention
     print(f"Sage Attention is found")
-except:
+except ImportError:
     sageattention = None
 
 @torch.compile(mode="max-autotune-no-cudagraphs", dynamic=True)

--- a/kandinsky/t2v_pipeline.py
+++ b/kandinsky/t2v_pipeline.py
@@ -230,7 +230,7 @@ class Kandinsky5T2VPipeline:
                 with open(adapter_config, "r") as f:
                     adapter_config = json.load(f)
                 adapter_config = LoraConfig(**adapter_config)
-            except:
+            except (FileNotFoundError, json.JSONDecodeError, TypeError):
                 raise TypeError(f"adapter_config should be an instance of PeftConfig or a path to a json file.")
         self.peft_config[adapter_name] = adapter_config
 

--- a/kandinsky/utils.py
+++ b/kandinsky/utils.py
@@ -58,7 +58,7 @@ def get_video_pipeline(
         local_rank, world_size = int(os.environ["LOCAL_RANK"]), int(
             os.environ["WORLD_SIZE"]
         )
-    except:
+    except (KeyError, ValueError):
         local_rank, world_size = 0, 1
 
     torch.cuda.set_device(local_rank)
@@ -174,7 +174,7 @@ def get_distributed_pipeline(
 ):
     try:
         world_size = int(os.environ["WORLD_SIZE"])
-    except:
+    except (KeyError, ValueError):
         world_size = 1
 
     if world_size > 1:
@@ -243,7 +243,7 @@ def _get_TI2I_params(
         local_rank, world_size = int(os.environ["LOCAL_RANK"]), int(
             os.environ["WORLD_SIZE"]
         )
-    except:
+    except (KeyError, ValueError):
         local_rank, world_size = 0, 1
 
     assert not (world_size > 1 and offload), "Offloading available only with not parallel inference"


### PR DESCRIPTION
Replace bare `except:` with specific exception types across 5 files (9 sites).

**Changes:**
- `models/attention.py` (3): `except ImportError:` — optional flash_attn/sageattention imports
- `utils.py` (3): `except (KeyError, ValueError):` — env var access (LOCAL_RANK, WORLD_SIZE)
- `i2i_pipeline.py`, `i2v_pipeline.py`, `t2v_pipeline.py` (3): `except (FileNotFoundError, json.JSONDecodeError, TypeError):` — adapter config loading

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt` and `SystemExit`, which can prevent clean shutdown during distributed training.